### PR TITLE
fix: router.handle -> router.fetch for itty-router v5

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -50,7 +50,7 @@ router.all('*', () => new Response('Not Found', { status: 404 }));
 export default {
   async fetch(request, env, ctx) {
     try {
-      const response = await router.handle(request, env, ctx);
+      const response = await router.fetch(request, env, ctx);
 
       // If a route returned a plain object, normalize to Response
       const normalized = response instanceof Response

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -6,7 +6,7 @@ account_id = "0bc21e3a5a9de1a4cc843be9c3e98121"
 
 # Production route
 routes = [
-  { pattern = "intel.chitty.cc", custom_domain = true }
+  { pattern = "intel.chitty.cc/*", zone_name = "chitty.cc" }
 ]
 
 # KV Namespaces


### PR DESCRIPTION
## Summary
- `router.handle()` does not exist in itty-router v5 — it was renamed to `router.fetch()`
- The old call hit the Proxy getter, created a phantom route, returned undefined, causing Worker to hang (1101)
- Switched from `custom_domain` to zone route to avoid routing conflicts

## Already deployed
Fix is live on `intel.chitty.cc` — health check returning 200.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal request handling method call.
  * Modified production route configuration for improved request pattern matching and zone management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->